### PR TITLE
Check phone numbers using a regular expression

### DIFF
--- a/src/Validator/VerifyPhoneNumber.php
+++ b/src/Validator/VerifyPhoneNumber.php
@@ -8,6 +8,8 @@ use Laminas\Validator\AbstractValidator;
 use Twilio\Exceptions\TwilioException;
 use Twilio\Rest\Client;
 
+use function preg_match;
+
 final class VerifyPhoneNumber extends AbstractValidator
 {
     public const string MSG_INVALID_PHONE_NUMBER   = 'msgInvalidPhoneNumber';
@@ -24,12 +26,25 @@ final class VerifyPhoneNumber extends AbstractValidator
     }
 
     /**
+     * The function checks if the supplied value is valid phone number
+     *
+     * It first checks the number against Twilio's E.164 regex, and if that passes,
+     * it makes a request to Twilio's Lookup API (V2).
+     *
+     * @link https://www.twilio.com/docs/glossary/what-e164
+     * @link https://www.twilio.com/docs/lookup/v2-api
+     *
      * @param mixed $value
      * @return bool
      */
     public function isValid($value)
     {
         $this->setValue($value);
+
+        if (preg_match("/^\+[1-9]\d{1,14}$/", (string) $value) !== 1) {
+            $this->error(self::MSG_INVALID_PHONE_NUMBER);
+            return false;
+        }
 
         try {
             $lookups      = $this->twilio->lookups;

--- a/src/Validator/VerifyPhoneNumber.php
+++ b/src/Validator/VerifyPhoneNumber.php
@@ -7,7 +7,6 @@ namespace Settermjd\Validator;
 use Laminas\Validator\AbstractValidator;
 use Twilio\Exceptions\TwilioException;
 use Twilio\Rest\Client;
-use Twilio\Rest\Lookups;
 
 final class VerifyPhoneNumber extends AbstractValidator
 {
@@ -33,9 +32,8 @@ final class VerifyPhoneNumber extends AbstractValidator
         $this->setValue($value);
 
         try {
-            $lookups = $this->twilio->__get("lookups");
-            /** @var Lookups\V2 $v2 */
-            $v2           = $lookups->__call("getV2", []);
+            $lookups      = $this->twilio->lookups;
+            $v2           = $lookups->v2;
             $phoneNumbers = $v2->phoneNumbers((string) $value);
             $phoneNumber  = $phoneNumbers->fetch();
         } catch (TwilioException $e) {

--- a/test/Validator/VerifyPhoneNumberTest.php
+++ b/test/Validator/VerifyPhoneNumberTest.php
@@ -47,8 +47,8 @@ class VerifyPhoneNumberTest extends TestCase
         /** @var MockObject $lookups */
         $lookups = $this->createMock(Lookups::class);
         $lookups->expects($this->once())
-            ->method("__call")
-            ->with("getV2", [])
+            ->method("__get")
+            ->with("v2")
             ->willReturn($v2);
 
         /** @var MockObject $client */
@@ -88,8 +88,8 @@ class VerifyPhoneNumberTest extends TestCase
         /** @var MockObject $lookups */
         $lookups = $this->createMock(Lookups::class);
         $lookups->expects($this->once())
-            ->method("__call")
-            ->with("getV2", [])
+            ->method("__get")
+            ->with("v2")
             ->willReturn($v2);
 
         /** @var MockObject $client */

--- a/test/Validator/VerifyPhoneNumberTest.php
+++ b/test/Validator/VerifyPhoneNumberTest.php
@@ -20,6 +20,27 @@ use function sprintf;
 
 class VerifyPhoneNumberTest extends TestCase
 {
+    #[TestWith(['+61000a00000'])]
+    #[TestWith(['+61000@00000'])]
+    #[TestWith(['61000000000'])]
+    #[TestWith(['-61000000000'])]
+    #[TestWith(['61'])]
+    public function testPhoneNumbersMustPassE164Regex(string $invalidPhoneNumber): void
+    {
+        $validator = new VerifyPhoneNumber($this->createMock(Client::class));
+
+        $this->assertFalse($validator->isValid($invalidPhoneNumber));
+        $this->assertSame(
+            [
+                "msgInvalidPhoneNumber" => sprintf(
+                    "'%s' is not a valid phone number",
+                    $invalidPhoneNumber
+                ),
+            ],
+            $validator->getMessages()
+        );
+    }
+
     #[TestWith(['+61000000000', true])]
     #[TestWith(['+61', false])]
     public function testValidPhoneNumbersValidateSuccessfully(string $phoneNumber, bool $phoneNumberIsValid): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

It's a small change, but intended to make checks a lot quicker by using a regex to perform an initial check of the supplied value before making a much more expensive network call.