### PR TITLE
Fix bug in the VerifyPhoneNumberFactory

### DIFF
--- a/src/Validator/VerifyPhoneNumberFactory.php
+++ b/src/Validator/VerifyPhoneNumberFactory.php
@@ -6,8 +6,8 @@ namespace Settermjd\LaminasPhoneNumberValidator\Validator;
 
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
-use Settermjd\LaminasPhoneNumberValidator\Factory\TwilioRestClientFactory;
 use Settermjd\LaminasPhoneNumberValidator\InputFilter\QueryParametersInputFilter;
+use Twilio\Rest\Client;
 
 /**
  * VerifyPhoneNumberFactory is a factory class that returns an instantiated VerifyPhoneNumber instance
@@ -22,8 +22,9 @@ class VerifyPhoneNumberFactory
     public function __invoke(ContainerInterface $container): VerifyPhoneNumber
     {
         return new VerifyPhoneNumber(
-            $container->get(TwilioRestClientFactory::class),
+            $container->get(Client::class),
             $container->get(QueryParametersInputFilter::class),
+            [],
             $container->has(CacheInterface::class)
                 ? $container->get(CacheInterface::class)
                 : null,

--- a/test/Validator/VerifyPhoneNumberFactoryTest.php
+++ b/test/Validator/VerifyPhoneNumberFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Settermjd\LaminasPhoneNumberValidatorTest\Validator;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\SimpleCache\CacheInterface;
+use Settermjd\LaminasPhoneNumberValidator\InputFilter\QueryParametersInputFilter;
+use Settermjd\LaminasPhoneNumberValidator\Validator\VerifyPhoneNumber;
+use Settermjd\LaminasPhoneNumberValidator\Validator\VerifyPhoneNumberFactory;
+use Twilio\Rest\Client;
+
+class VerifyPhoneNumberFactoryTest extends TestCase
+{
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function testCanInvokeVerifyPhoneNumberProperly(bool $hasCache): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->atMost(3))
+            ->method('get')
+            ->willReturnOnConsecutiveCalls(
+                $this->createMock(Client::class),
+                new QueryParametersInputFilter(),
+                $hasCache ? $this->createMock(CacheInterface::class) : null,
+            );
+        $container
+            ->expects($this->atMost(3))
+            ->method('has')
+            ->with(CacheInterface::class)
+            ->willReturn($hasCache);
+
+        $this->assertInstanceOf(
+            VerifyPhoneNumber::class,
+            (new VerifyPhoneNumberFactory())->__invoke($container)
+        );
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I didn't see this earlier, but there was a bug in the `VerifyPhoneNumberFactory` where it attempted to retrieve a  `TwilioRestClientFactory` from the DI container instead of a Twilio HTTP Rest Client. I can only guess that it got through because there wasn't a test for the class up until now. 😢 

So, this change introduces a covering test class and corrects the bug in `VerifyPhoneNumberFactory`.